### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "estree-walker": "3.0.3",
     "hermes-parser": "0.35.0",
-    "lodash": "4.17.23"
+    "lodash": "4.18.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "chai": "^4.5.0",
-    "mocha": "^11.7.0"
+    "mocha": "^11.7.5"
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "estree-walker": "3.0.3",
-    "hermes-parser": "0.32.0",
+    "hermes-parser": "0.35.0",
     "lodash": "4.17.23"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabrainz/xgettext-js",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": "Andrew Duthie <andrew@andrewduthie.com>",
   "description": "xgettext string extractor tool capable of parsing JavaScript files",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.5.0",
     "mocha": "^11.7.0"
   },
   "packageManager": "yarn@4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metabrainz/xgettext-js@workspace:."
   dependencies:
-    chai: "npm:^4.2.0"
+    chai: "npm:^4.5.0"
     estree-walker: "npm:3.0.3"
     hermes-parser: "npm:0.35.0"
     lodash: "npm:4.18.1"
@@ -119,9 +119,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^4.2.0":
-  version: 4.3.10
-  resolution: "chai@npm:4.3.10"
+"chai@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "chai@npm:4.5.0"
   dependencies:
     assertion-error: "npm:^1.1.0"
     check-error: "npm:^1.0.3"
@@ -129,8 +129,8 @@ __metadata:
     get-func-name: "npm:^2.0.2"
     loupe: "npm:^2.3.6"
     pathval: "npm:^1.1.1"
-    type-detect: "npm:^4.0.8"
-  checksum: 10c0/c887d24f67be6fb554c7ebbde3bb0568697a8833d475e4768296916891ba143f25fc079f6eb34146f3dd5a3279d34c1f387c32c9a6ab288e579f948d9ccf53fe
+    type-detect: "npm:^4.1.0"
+  checksum: 10c0/b8cb596bd1aece1aec659e41a6e479290c7d9bee5b3ad63d2898ad230064e5b47889a3bc367b20100a0853b62e026e2dc514acf25a3c9385f936aa3614d4ab4d
   languageName: node
   linkType: hard
 
@@ -716,10 +716,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:^4.0.0, type-detect@npm:^4.0.8":
+"type-detect@npm:^4.0.0":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 10c0/8fb9a51d3f365a7de84ab7f73b653534b61b622aa6800aecdb0f1095a4a646d3f5eb295322127b6573db7982afcd40ab492d038cf825a42093a58b1e1353e0bd
+  languageName: node
+  linkType: hard
+
+"type-detect@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "type-detect@npm:4.1.0"
+  checksum: 10c0/df8157ca3f5d311edc22885abc134e18ff8ffbc93d6a9848af5b682730ca6a5a44499259750197250479c5331a8a75b5537529df5ec410622041650a7f293e2a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@ __metadata:
     chai: "npm:^4.2.0"
     estree-walker: "npm:3.0.3"
     hermes-parser: "npm:0.35.0"
-    lodash: "npm:4.17.23"
+    lodash: "npm:4.18.1"
     mocha: "npm:^11.7.0"
   languageName: unknown
   linkType: soft
@@ -438,10 +438,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,7 +27,7 @@ __metadata:
     estree-walker: "npm:3.0.3"
     hermes-parser: "npm:0.35.0"
     lodash: "npm:4.18.1"
-    mocha: "npm:^11.7.0"
+    mocha: "npm:^11.7.5"
   languageName: unknown
   linkType: soft
 
@@ -487,7 +487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mocha@npm:^11.7.0":
+"mocha@npm:^11.7.5":
   version: 11.7.5
   resolution: "mocha@npm:11.7.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@ __metadata:
   dependencies:
     chai: "npm:^4.2.0"
     estree-walker: "npm:3.0.3"
-    hermes-parser: "npm:0.32.0"
+    hermes-parser: "npm:0.35.0"
     lodash: "npm:4.17.23"
     mocha: "npm:^11.7.0"
   languageName: unknown
@@ -354,19 +354,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-estree@npm:0.32.0"
-  checksum: 10c0/3b67d1fe44336240ef7f9c40ecbf363279ba263d51efe120570c3862cc109e652fc09aebddfe6b73d0f0246610bee130e4064c359f1f4cbf002bdb1d99717ef2
+"hermes-estree@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-estree@npm:0.35.0"
+  checksum: 10c0/a88c9dc63b8b3679b1aeb43e72e977597096c1bd7d59978c952f1d6df6d1a517c4a817c70b1b701854996b485adfa66c2fc7f80871029a7f0c04306f6717b59a
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.32.0":
-  version: 0.32.0
-  resolution: "hermes-parser@npm:0.32.0"
+"hermes-parser@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-parser@npm:0.35.0"
   dependencies:
-    hermes-estree: "npm:0.32.0"
-  checksum: 10c0/5902d2c5d347c0629fba07a47eaad5569590ac69bc8bfb2e454e08d2dfbe1ebd989d88518dca2cba64061689b5eac5960ae6bd15a4a66600bbf377498a3234b7
+    hermes-estree: "npm:0.35.0"
+  checksum: 10c0/49d98093a2094758db5b536627c6cf5146b140f66e63143acf471c62f1d3fd8bd6ae10a33f2372f72e3653deda5d4615c6dae89d01248849440916209901fc4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

There are seven security alerts for dependencies, mainly two for `lodash`:
* CVE-2021-23337: https://github.com/advisories/GHSA-35jh-r3h4-6jhm
* CVE-2025-13465: https://github.com/advisories/GHSA-xxjr-mmjv-4gpg

## Solution

* Update all the dependencies without breaking changes. (No major version change.)
* Bump package version to `5.0.2` for release.